### PR TITLE
fixed controller method for gplus

### DIFF
--- a/modules/Application/Controller/Links.php
+++ b/modules/Application/Controller/Links.php
@@ -5,7 +5,7 @@ use Application\Controller\Shared as SharedController;
 
 class Links extends SharedController
 {
-    public function indexAction()
+    public function gplusAction()
     {
         return $this->redirect('https://plus.google.com/communities/100606932222119087997');
     }
@@ -19,5 +19,4 @@ class Links extends SharedController
     {
         return $this->redirect('http://www.twitter.com/ppi_framework');
     }
-
 }


### PR DESCRIPTION
The router for google plus is { _controller: "Application:Links:gplus"}
so the method should be gplusAction, and not indexAction.
